### PR TITLE
Data partner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ pip install semanticscholar
 
 # Usage
 Programmatically access paper and author data.
+Can be used to access both the public API or the S2 Data Partner's API using a private key.
 
-## Paper Lookup
+## Paper Lookup (Public API)
 To access paper data:
 ```python
 >>> from semanticscholar import SemanticScholar
@@ -28,11 +29,11 @@ dict_keys(['abstract', 'arxivId', 'authors', 'citationVelocity', 'citations', 'd
 ...     print(author['name'])
 ...     print(author['authorId'])
 ...
-Alan M. Turing
+'Alan M. Turing'
 2262347
 ```
 
-## Author Lookup
+## Author Lookup (Public API)
 To access author data:
 ```python
 >>> from semanticscholar import SemanticScholar
@@ -44,4 +45,31 @@ dict_keys(['aliases', 'authorId', 'citationVelocity', 'influentialCitationCount'
 'Alan M. Turing'
 >>> len(author['papers'])
 77
+```
+
+## Optional arguments
+For each request, you can specify the timeout length, and whether or not to retrieve references unknown to Semantic Scholar. The default behaviour is `timeout=2` and `include_unknown_references=False`.
+Alternatively, you can change these defaults for requests by providing the additional arguments when instantiating the `SemanticScholar` class:
+```python
+>>> from semanticscholar import SemanticScholar
+>>> sch = SemanticScholar(timeout=5, include_unknown_references=True)
+>>> paper = sch.paper('0796f6cd7f0403a854d67d525e9b32af3b277331')
+>>> for ref in paper['references']:
+...     if not ref['paperId']: print(ref['title'])
+...
+'Corpusbased method for automatic identification of support'
+'Automatically constructing extraction patterns from untagged text'
+'Corpusbased method for automatic identification of support verbs for nominalizations'
+'Stretched Verb Constructions in English Routledge Studies in Germanic Linguistics. Routledge (Taylor and Francis)'
+', Aria Haghighi , and Christopher D . Manning . 2008 . A global joint model for semantic role labeling'
+'On-demand information extraction Association for Computational Lin- guistics'
+```
+
+## Accessing the Data Partner's API
+Lastly, if you are a Semantic Scholar Data Partner, you can provide the URL and private key as optional arguments:
+```python
+>>> from semanticscholar import SemanticScholar
+>>> s2_api_url = 'https://partner.semanticscholar.org/v1'
+>>> s2_api_key = '40-CharacterPrivateKeyProvidedToPartners'
+>>> sch = SemanticScholar(api_url=s2_api_url, api_key=s2_api_key)
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Programmatically access paper and author data.
 ## Paper Lookup
 To access paper data:
 ```python
->>> import semanticscholar as sch
+>>> from semanticscholar import SemanticScholar
+>>> sch = SemanticScholar()
 >>> paper = sch.paper('10.1093/mind/lix.236.433', timeout=2)
 >>> paper.keys()
 dict_keys(['abstract', 'arxivId', 'authors', 'citationVelocity', 'citations', 'doi',
@@ -34,7 +35,8 @@ Alan M. Turing
 ## Author Lookup
 To access author data:
 ```python
->>> import semanticscholar as sch
+>>> from semanticscholar import SemanticScholar
+>>> sch = SemanticScholar()
 >>> author = sch.author(2262347, timeout=2)
 >>> author.keys()
 dict_keys(['aliases', 'authorId', 'citationVelocity', 'influentialCitationCount', 'name', 'papers', 'url'])

--- a/semanticscholar/__init__.py
+++ b/semanticscholar/__init__.py
@@ -1,1 +1,1 @@
-from .restful import paper, author
+from .restful import SemanticScholar

--- a/semanticscholar/restful.py
+++ b/semanticscholar/restful.py
@@ -6,74 +6,77 @@ from tenacity import (retry,
 
 API_URL = 'https://api.semanticscholar.org/v1'
 
+class SemanticScholar:
+    def __init__(self):
+        pass
 
-def paper(id, timeout=2, include_unknown_references=False) -> dict:
+    def paper(self, id, timeout=2, include_unknown_references=False) -> dict:
 
-    '''Paper lookup
+        '''Paper lookup
 
-    :param str id: S2PaperId, DOI or ArXivId.
-    :param float timeout: an exception is raised
-        if the server has not issued a response for timeout seconds
-    :param bool include_unknown_references :
-        (optional) include non referenced paper.
-    :returns: paper data or empty :class:`dict` if not found.
-    :rtype: :class:`dict`
-    '''
+        :param str id: S2PaperId, DOI or ArXivId.
+        :param float timeout: an exception is raised
+            if the server has not issued a response for timeout seconds
+        :param bool include_unknown_references :
+            (optional) include non referenced paper.
+        :returns: paper data or empty :class:`dict` if not found.
+        :rtype: :class:`dict`
+        '''
 
-    data = __get_data('paper', id, timeout, include_unknown_references)
+        data = self.__get_data('paper', id, timeout, include_unknown_references)
 
-    return data
-
-
-def author(id, timeout=2) -> dict:
-
-    '''Author lookup
-
-    :param str id: S2AuthorId.
-    :param float timeout: an exception is raised
-        if the server has not issued a response for timeout seconds
-    :returns: author data or empty :class:`dict` if not found.
-    :rtype: :class:`dict`
-    '''
-
-    data = __get_data('author', id, timeout)
-
-    return data
+        return data
 
 
-@retry(
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(ConnectionRefusedError),
-    stop=stop_after_attempt(10)
-    )
-def __get_data(method, id, timeout, include_unknown_references=False) -> dict:
+    def author(self, id, timeout=2) -> dict:
 
-    '''Get data from Semantic Scholar API
+        '''Author lookup
 
-    :param str method: 'paper' or 'author'.
-    :param str id: id of the correponding method
-    :param float timeout: an exception is raised
-        if the server has not issued a response for timeout seconds
-    :returns: data or empty :class:`dict` if not found.
-    :rtype: :class:`dict`
-    '''
+        :param str id: S2AuthorId.
+        :param float timeout: an exception is raised
+            if the server has not issued a response for timeout seconds
+        :returns: author data or empty :class:`dict` if not found.
+        :rtype: :class:`dict`
+        '''
 
-    data = {}
-    method_types = ['paper', 'author']
-    if method not in method_types:
-        raise ValueError(
-            'Invalid method type. Expected one of: {}'.format(method_types))
+        data = self.__get_data('author', id, timeout)
 
-    url = '{}/{}/{}'.format(API_URL, method, id)
-    if include_unknown_references:
-        url += '?include_unknown_references=true'
-    r = requests.get(url, timeout=timeout)
+        return data
 
-    if r.status_code == 200:
-        data = r.json()
-        if len(data) == 1 and 'error' in data:
-            data = {}
-    elif r.status_code == 429:
-        raise ConnectionRefusedError('HTTP status 429 Too Many Requests.')
 
-    return data
+    @retry(
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(ConnectionRefusedError),
+        stop=stop_after_attempt(10)
+        )
+    def __get_data(self, method, id, timeout, include_unknown_references=False) -> dict:
+
+        '''Get data from Semantic Scholar API
+
+        :param str method: 'paper' or 'author'.
+        :param str id: id of the correponding method
+        :param float timeout: an exception is raised
+            if the server has not issued a response for timeout seconds
+        :returns: data or empty :class:`dict` if not found.
+        :rtype: :class:`dict`
+        '''
+
+        data = {}
+        method_types = ['paper', 'author']
+        if method not in method_types:
+            raise ValueError(
+                'Invalid method type. Expected one of: {}'.format(method_types))
+
+        url = '{}/{}/{}'.format(API_URL, method, id)
+        if include_unknown_references:
+            url += '?include_unknown_references=true'
+        r = requests.get(url, timeout=timeout)
+
+        if r.status_code == 200:
+            data = r.json()
+            if len(data) == 1 and 'error' in data:
+                data = {}
+        elif r.status_code == 429:
+            raise ConnectionRefusedError('HTTP status 429 Too Many Requests.')
+
+        return data

--- a/semanticscholar/restful.py
+++ b/semanticscholar/restful.py
@@ -4,13 +4,20 @@ from tenacity import (retry,
                       retry_if_exception_type,
                       stop_after_attempt)
 
-API_URL = 'https://api.semanticscholar.org/v1'
-
 class SemanticScholar:
-    def __init__(self):
-        pass
 
-    def paper(self, id, timeout=2, include_unknown_references=False) -> dict:
+    url = 'https://api.semanticscholar.org/v1'
+    auth_header = {}
+    timeout = 0
+    incl_unkn_refs = False
+
+    def __init__(self, api_url=None, api_key=None, timeout=2, include_unknown_references=False):
+        if not None==api_url: self.url = api_url
+        if not None==api_key: self.auth_header = {'x-api-key': api_key}
+        self.timeout = timeout
+        self.incl_unkn_refs = include_unknown_references
+
+    def paper(self, id, timeout=None, include_unknown_references=None) -> dict:
 
         '''Paper lookup
 
@@ -22,13 +29,16 @@ class SemanticScholar:
         :returns: paper data or empty :class:`dict` if not found.
         :rtype: :class:`dict`
         '''
+        # Default behaviour for optional arguments
+        if None==timeout: timeout = self.timeout
+        if None==include_unknown_references: include_unknown_references = self.incl_unkn_refs
 
         data = self.__get_data('paper', id, timeout, include_unknown_references)
 
         return data
 
 
-    def author(self, id, timeout=2) -> dict:
+    def author(self, id, timeout=None) -> dict:
 
         '''Author lookup
 
@@ -38,8 +48,10 @@ class SemanticScholar:
         :returns: author data or empty :class:`dict` if not found.
         :rtype: :class:`dict`
         '''
+        # Default behaviour for optional arguments
+        if None==timeout: timeout = self.timeout
 
-        data = self.__get_data('author', id, timeout)
+        data = self.__get_data('author', id, timeout, False)
 
         return data
 
@@ -49,7 +61,7 @@ class SemanticScholar:
         retry=retry_if_exception_type(ConnectionRefusedError),
         stop=stop_after_attempt(10)
         )
-    def __get_data(self, method, id, timeout, include_unknown_references=False) -> dict:
+    def __get_data(self, method, id, timeout, include_unknown_references) -> dict:
 
         '''Get data from Semantic Scholar API
 
@@ -67,15 +79,17 @@ class SemanticScholar:
             raise ValueError(
                 'Invalid method type. Expected one of: {}'.format(method_types))
 
-        url = '{}/{}/{}'.format(API_URL, method, id)
+        url = '{}/{}/{}'.format(self.url, method, id)
         if include_unknown_references:
             url += '?include_unknown_references=true'
-        r = requests.get(url, timeout=timeout)
+        r = requests.get(url, timeout=timeout, headers=self.auth_header)
 
         if r.status_code == 200:
             data = r.json()
             if len(data) == 1 and 'error' in data:
                 data = {}
+        elif r.status_code == 403:
+            raise PermissionError('HTTP status 403 Forbidden.')
         elif r.status_code == 429:
             raise ConnectionRefusedError('HTTP status 429 Too Many Requests.')
 


### PR DESCRIPTION
Added support for [S2 data partners](https://pages.semanticscholar.org/data-partners) to use their private API key. Another benefit is that the default behavior for timeouts and unknown reference handling can be changed at instantiation.

The read-me has been updated to reflect the changes -- calls to `paper()` and `author()` methods are backwards compatible, but the preamble is slightly altered.