### PR TITLE
Spelling fixes object not found exception

### DIFF
--- a/semanticscholar/ApiRequester.py
+++ b/semanticscholar/ApiRequester.py
@@ -6,7 +6,7 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_fixed)
 
 from semanticscholar.SemanticScholarException import \
-    BadQueryParametersException, ObjectNotFoundExeception
+    BadQueryParametersException, ObjectNotFoundException
 
 
 class ApiRequester:
@@ -75,7 +75,7 @@ class ApiRequester:
             raise PermissionError('HTTP status 403 Forbidden.')
         elif r.status_code == 404:
             data = r.json()
-            raise ObjectNotFoundExeception(data['error'])
+            raise ObjectNotFoundException(data['error'])
         elif r.status_code == 429:
             raise ConnectionRefusedError('HTTP status 429 Too Many Requests.')
         elif r.status_code in [500, 504]:

--- a/semanticscholar/SemanticScholar.py
+++ b/semanticscholar/SemanticScholar.py
@@ -94,7 +94,7 @@ class SemanticScholar:
         :param list fields: (optional) list of the fields to be returned.
         :returns: paper data
         :rtype: :class:`semanticscholar.Paper.Paper`
-        :raises: ObjectNotFoundExeception: if Paper ID not found.
+        :raises: ObjectNotFoundException: if Paper ID not found.
         '''
 
         if not fields:
@@ -375,7 +375,7 @@ class SemanticScholar:
         :param str author_id: S2AuthorId.
         :returns: author data
         :rtype: :class:`semanticscholar.Author.Author`
-        :raises: ObjectNotFoundExeception: if Author ID not found.
+        :raises: ObjectNotFoundException: if Author ID not found.
         '''
 
         if not fields:

--- a/semanticscholar/SemanticScholarException.py
+++ b/semanticscholar/SemanticScholarException.py
@@ -9,5 +9,5 @@ class BadQueryParametersException(SemanticScholarException):
     '''Invalid query params or unsupported fields.'''
 
 
-class ObjectNotFoundExeception(SemanticScholarException):
+class ObjectNotFoundException(SemanticScholarException):
     '''Paper or Author ID not found'''

--- a/tests/test_semanticscholar.py
+++ b/tests/test_semanticscholar.py
@@ -13,7 +13,7 @@ from semanticscholar.PublicationVenue import PublicationVenue
 from semanticscholar.Reference import Reference
 from semanticscholar.SemanticScholar import SemanticScholar
 from semanticscholar.SemanticScholarException import (
-    BadQueryParametersException, ObjectNotFoundExeception)
+    BadQueryParametersException, ObjectNotFoundException)
 from semanticscholar.Tldr import Tldr
 
 test_vcr = vcr.VCR(
@@ -238,7 +238,7 @@ class SemanticScholarTest(unittest.TestCase):
         methods = [self.sch.get_paper, self.sch.get_author]
         for method in methods:
             with self.subTest(subtest=method.__name__):
-                self.assertRaises(ObjectNotFoundExeception, method, 0)
+                self.assertRaises(ObjectNotFoundException, method, 0)
 
     @test_vcr.use_cassette
     def test_bad_query_parameters(self):


### PR DESCRIPTION
First of all. Thank you for this wonderful tool! I use it a lot. 
This PR fixes the spelling of ObjectNotFoundExeception to ObjectNotFoundException for consistency. 