### PR TITLE
feat: custom some args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST.in
 .coverage
 docs/
 .devcontainer/
+.idea

--- a/semanticscholar/SemanticScholar.py
+++ b/semanticscholar/SemanticScholar.py
@@ -18,7 +18,8 @@ class SemanticScholar():
                 timeout: int = 30,
                 api_key: str = None,
                 api_url: str = None,
-                debug: bool = False
+                debug: bool = False,
+                retry: bool = True,
             ) -> None:
         '''
         :param float timeout: (optional) an exception is raised\
@@ -26,6 +27,7 @@ class SemanticScholar():
         :param str api_key: (optional) private API key.
         :param str api_url: (optional) custom API url.
         :param bool debug: (optional) enable debug mode.
+        :param bool retry: enable retry mode.
         '''
         nest_asyncio.apply()
         self._timeout = timeout
@@ -34,7 +36,8 @@ class SemanticScholar():
             timeout=timeout,
             api_key=api_key,
             api_url=api_url,
-            debug=debug
+            debug=debug,
+            retry=retry
         )
 
     @property


### PR DESCRIPTION
1.  support set max_results
2.  support set with_retry,  Because of the rate limiting of the SemanticScholar API, we want to fail fast. When encountering an HTTP status of 429, we want to fail quickly without retrying.