### PR TITLE
FIX:Does not support quotes in the query string #98

### DIFF
--- a/semanticscholar/ApiRequester.py
+++ b/semanticscholar/ApiRequester.py
@@ -105,7 +105,7 @@ class ApiRequester:
             payload: dict = None
     ) -> Union[dict, List[dict]]:
 
-        url = f'{url}?{parameters.lstrip("&")}'
+        parameters=parameters.lstrip("&")
         method = 'POST' if payload else 'GET'
 
         logger.debug(f'HTTP Request: {method} {url}')
@@ -115,7 +115,7 @@ class ApiRequester:
 
         async with httpx.AsyncClient() as client:
             r = await client.request(
-                method, url, timeout=self._timeout, headers=headers,
+                method, url, params=parameters,timeout=self._timeout, headers=headers,
                 json=payload)
 
         data = {}


### PR DESCRIPTION
I fixed : Does not support quotes in the query string #98.
I also want to use bulk search API and it needs to support quotes.
I just changed the ApiRequester.py to pass the parameters to params.